### PR TITLE
Configuration improvements and cleanup + some GCP API cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,9 @@ AUTH_PROVIDERS:
 $ export GIFTLESS_CONFIG_FILE=giftless.yaml
 ```
 
-
 5. Start the Giftless server (by docker or Python).
 
-
-6. Initialzie your git repo and connect it with the
+6. Initialize your git repo and connect it with the
 remote project:
 
 ```bash
@@ -178,31 +176,42 @@ Modify your `giftless.yaml` file according to the following config:
 
 #### Google Cloud Platform Support
 
-Make sure to obtain your `credentials.json` file. More information 
-[here](https://console.cloud.google.com/apis/credentials/serviceaccountkey).
-You can export it directly with 
+To use Google Cloud Storage as a backend, you'll first need:
+* A Google Cloud Storage container to store objects in
+* an account key JSON file (see [here](https://console.cloud.google.com/apis/credentials/serviceaccountkey)).
 
-```bash
-export GOOGLE_APPLICATION_CREDENTIALS="PATH_TO/credentials.json"
-```
+The key must be associated with either a user or a service account, and should have
+read / write permissions on objects in the container.
 
-Make sure to also specify the path into the YAML file:
+You can deploy the account key JSON file and provide the path to it as 
+the `account_key_file` storage option:
 
-```bash
+```yaml
 TRANSFER_ADAPTERS:
   basic:
     factory: giftless.transfer.basic_streaming:factory
     options:
-      storage_class: ..storage.google_cloud:GoogleCloudBlobStorage
+      storage_class: giftless.storage.google_cloud:GoogleCloudStorage
       storage_options:
-        bucket_name: datahub-bbb
-        api_key: myAPI-key
-        account_json_path: PATH_TO/credentials.json
-AUTH_PROVIDERS:
-  - giftless.auth.allow_anon:read_write
+        project_name: my-gcp-project
+        bucket_name: git-lfs
+        account_key_file: /path/to/credentials.json
 ```
 
-`api-key` and `account_json_path` are optional parameters.
+Alternatively, you can base64-encode the contents of the JSON file and provide
+it inline as `account_key_base64`: 
+
+```yaml
+TRANSFER_ADAPTERS:
+  basic:
+    factory: giftless.transfer.basic_streaming:factory
+    options:
+      storage_class: giftless.storage.google_cloud:GoogleCloudStorage
+      storage_options:
+        project_name: my-gcp-project
+        bucket_name: git-lfs
+        account_key_base64: S0m3B4se64RandomStuff.....ThatI5Redac7edHeReF0rRead4b1lity==
+```
 
 After configuring your `giftless.yaml` file, export it:
 
@@ -234,7 +243,7 @@ YAML_CONTENT="TRANSFER_ADAPTERS:
   basic:
     factory: giftless.transfer.basic_streaming:factory
     options:
-      storage_class: ..storage.google_cloud:GoogleCloudBlobStorage
+      storage_class: ..storage.google_cloud:GoogleCloudStorage
       storage_options:
         bucket_name: datahub-bbb
         api_key: API_KEY

--- a/README.md
+++ b/README.md
@@ -230,16 +230,17 @@ Here is an example of how to run it:
 
 See `giftless/config.py` for some default configuration options.
 
-#### Configuration over .env files
+#### Configuration using .env files
 
-[WIP] It is possible to use an `.env` file 
-isntead of a YAML file in case you need to deploy the project
-in a PaaS, such as Heroku. At this time, we only support a
-raw format where we dump the content of `giftless.yaml` 
-into an env var anmed `YAML_CONTENT`:
+[WIP] It is possible to use an `.env` file instead of a YAML file in case you 
+need to deploy the project in a platform which does not support deploying 
+configuration in files, such as Heroku.
+
+At this time, we only support a raw format where we dump the content of 
+`giftless.yaml` into an env var anmed `YAML_CONTENT`:
 
 ```bash
-YAML_CONTENT="TRANSFER_ADAPTERS:
+GIFTLESS_CONFIG_STR="TRANSFER_ADAPTERS:
   basic:
     factory: giftless.transfer.basic_streaming:factory
     options:
@@ -252,8 +253,12 @@ AUTH_PROVIDERS:
 "
 ```
 
-Note: **`.env` files have priority over YAML files. If you have both, this will be the primary source of configuration at this time.**
+**Note #1**: As YAML is a superset of JSON, you can also provide a more compact
+JSON string instead.
 
+**Note #2:**: If you provide both a YAML file (as `GIFTLESS_CONFIG_FILE`) and a
+literal YAML string (as `GIFTLESS_CONFIG_STR`), the two will be merged, with values
+from the YAML string taking precedence over values from the YAML file.
 
 #### Transfer Adapters
 

--- a/giftless/config.py
+++ b/giftless/config.py
@@ -69,7 +69,7 @@ def _compose_config(additional_config: Optional[Dict] = None) -> figcan.Configur
         environ.pop(f'{ENV_PREFIX}CONFIG_FILE')
 
     if environ.get(f'{ENV_PREFIX}CONFIG_STR'):
-        config_from_file = yaml.safe_load(environ.get(f'{ENV_PREFIX}CONFIG_STR'))
+        config_from_file = yaml.safe_load(environ[f'{ENV_PREFIX}CONFIG_STR'])
         config.apply(config_from_file)
         environ.pop(f'{ENV_PREFIX}CONFIG_STR')
 

--- a/giftless/config.py
+++ b/giftless/config.py
@@ -59,17 +59,23 @@ def configure(app, additional_config: Optional[Dict] = None):
 def _compose_config(additional_config: Optional[Dict] = None) -> figcan.Configuration:
     """Compose configuration object from all available sources
     """
-    YAML_STR_FROM_ENV = os.getenv("YAML_CONTENT")
     config = figcan.Configuration(default_config)
-    if YAML_STR_FROM_ENV:
-        config_from_file = yaml.safe_load(YAML_STR_FROM_ENV)
-        config.apply(config_from_file)
-    elif os.environ.get(f'{ENV_PREFIX}CONFIG_FILE'):
-        with open(os.environ[f'{ENV_PREFIX}CONFIG_FILE']) as f:
+    environ = dict(os.environ)  # Copy the environment as we're going to change it
+
+    if environ.get(f'{ENV_PREFIX}CONFIG_FILE'):
+        with open(environ[f'{ENV_PREFIX}CONFIG_FILE']) as f:
             config_from_file = yaml.safe_load(f)
-            config.apply(config_from_file)
-        os.environ.pop(f'{ENV_PREFIX}CONFIG_FILE')
+        config.apply(config_from_file)
+        environ.pop(f'{ENV_PREFIX}CONFIG_FILE')
+
+    if environ.get(f'{ENV_PREFIX}CONFIG_STR'):
+        config_from_file = yaml.safe_load(environ.get(f'{ENV_PREFIX}CONFIG_STR'))
+        config.apply(config_from_file)
+        environ.pop(f'{ENV_PREFIX}CONFIG_STR')
+
+    config.apply_flat(environ, prefix=ENV_PREFIX)  # type: ignore
+
     if additional_config:
         config.apply(additional_config)
-    config.apply_flat(os.environ, prefix=ENV_PREFIX)  # type: ignore
+
     return config

--- a/tests/storage/test_google_cloud.py
+++ b/tests/storage/test_google_cloud.py
@@ -17,7 +17,7 @@ def mocked_gcp():
     mock_blob.download_as_string.return_value.decode.return_value = "file_content"
     attrs = {'put.return_value': 500,
              'exists.return_value': True, 'get_size.return_value': 500}
-    patcher = patch('giftless.storage.google_cloud.GoogleCloudBlobStorage',
+    patcher = patch('giftless.storage.google_cloud.GoogleCloudStorage',
                     bucket_name="datahub-test", storage_client=storage_client_mock,
                     account_json_path="credentials.json", **attrs)
     return patcher


### PR DESCRIPTION
Improve configuration handling by:
- Making GCP load it's credentials from the file or base64 JSON literal that is provided in the YAML config (resolving #35)
- Rename the `YAML_CONTENT` env var to the more aptly named `GIFTLESS_CONFIG_STR`
- Updating README in accordance + improving it a bit

Also, because why not, I renamed the Google Cloud storage backend from `GoogleCloudBlobStorage` to `GoogleCloudStorage`, because really it is not called "blob storage" in Google (only in Azure). 