### PR TITLE
Add Unauthorized error log

### DIFF
--- a/giftless/auth/__init__.py
+++ b/giftless/auth/__init__.py
@@ -146,9 +146,11 @@ class Authentication:
                 current_identity = authn(flask_request)
                 if current_identity is not None:
                     return current_identity
-            except Unauthorized:
+            except Unauthorized as e:
                 # An authenticator is telling us the provided identity is invalid
                 # We should stop looking and return "no identity"
+                log = logging.getLogger(__name__)
+                log.debug(e.description)
                 return None
 
         return self._default_identity


### PR DESCRIPTION
The current logic catches an expired token exception but return to the user a: `401 Unauthorized: User identity is required` message. That can be tricky when debugging since the identity/token has been provided, but the main reason of failure is that it has expired.

I have added a Debug log to actually print any Unauthorized exception message so it is easy to debug and understand the error.