### PR TITLE
Handle filenames for basic streaming transfer adapter.

### DIFF
--- a/giftless/transfer/__init__.py
+++ b/giftless/transfer/__init__.py
@@ -6,10 +6,9 @@ for more information about what transfer APIs do in Git LFS.
 from abc import ABC
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
-from urllib.parse import urlencode
 
 from giftless.auth import Authentication, authentication
-from giftless.util import get_callable, add_query_params
+from giftless.util import add_query_params, get_callable
 from giftless.view import ViewProvider
 
 _registered_adapters: Dict[str, 'TransferAdapter'] = {}

--- a/giftless/transfer/__init__.py
+++ b/giftless/transfer/__init__.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 from urllib.parse import urlencode
 
 from giftless.auth import Authentication, authentication
-from giftless.util import get_callable
+from giftless.util import get_callable, add_query_params
 from giftless.view import ViewProvider
 
 _registered_adapters: Dict[str, 'TransferAdapter'] = {}
@@ -55,9 +55,8 @@ class PreAuthorizingTransferAdapter(TransferAdapter, ABC):
 
         params = self._auth_module.preauth_handler.get_authz_query_params(identity, org, repo, actions, oid,
                                                                           lifetime=lifetime)
-        qs = urlencode(params)
-        sep = '&' if '?' in original_url else '?'
-        return f'{original_url}{sep}{qs}'
+
+        return add_query_params(original_url, params)
 
     def _preauth_headers(self, org: str, repo: str, actions: Optional[Set[str]] = None,
                          oid: Optional[str] = None, lifetime: Optional[int] = None) -> Dict[str, str]:

--- a/giftless/transfer/basic_streaming.py
+++ b/giftless/transfer/basic_streaming.py
@@ -8,7 +8,6 @@ interface through which additional streaming backends can be implemented.
 
 import os
 from typing import Any, Dict, Optional
-from urllib.parse import urlencode
 
 from flask import Response, request, url_for
 from flask_classful import route
@@ -19,7 +18,7 @@ from giftless.exc import InvalidPayload, NotFound
 from giftless.schema import ObjectSchema
 from giftless.storage import StreamingStorage, VerifiableStorage
 from giftless.transfer import PreAuthorizingTransferAdapter, ViewProvider
-from giftless.util import get_callable
+from giftless.util import get_callable, add_query_params
 from giftless.view import BaseView
 
 
@@ -152,9 +151,7 @@ class BasicStreamingTransferAdapter(PreAuthorizingTransferAdapter, ViewProvider)
             preauth_url = self._preauth_url(download_url, organization, repo, actions={'read'}, oid=oid)
 
             params = {'filename': extra.get('filename') if extra else None}
-            qs = urlencode(params)
-            sep = '&' if '?' in preauth_url else '?'
-            preauth_url_with_params = f'{preauth_url}{sep}{qs}'
+            preauth_url_with_params = add_query_params(preauth_url, params)
 
             response['actions'] = {
                 "download": {

--- a/giftless/transfer/basic_streaming.py
+++ b/giftless/transfer/basic_streaming.py
@@ -18,7 +18,7 @@ from giftless.exc import InvalidPayload, NotFound
 from giftless.schema import ObjectSchema
 from giftless.storage import StreamingStorage, VerifiableStorage
 from giftless.transfer import PreAuthorizingTransferAdapter, ViewProvider
-from giftless.util import get_callable, add_query_params
+from giftless.util import add_query_params, get_callable
 from giftless.view import BaseView
 
 

--- a/giftless/transfer/basic_streaming.py
+++ b/giftless/transfer/basic_streaming.py
@@ -8,6 +8,7 @@ interface through which additional streaming backends can be implemented.
 
 import os
 from typing import Any, Dict, Optional
+from urllib.parse import urlencode
 
 from flask import Response, request, url_for
 from flask_classful import route
@@ -20,7 +21,6 @@ from giftless.storage import StreamingStorage, VerifiableStorage
 from giftless.transfer import PreAuthorizingTransferAdapter, ViewProvider
 from giftless.util import get_callable
 from giftless.view import BaseView
-from urllib.parse import urlencode
 
 
 class VerifyView(BaseView):

--- a/giftless/transfer/basic_streaming.py
+++ b/giftless/transfer/basic_streaming.py
@@ -82,7 +82,7 @@ class ObjectsView(BaseView):
         path = os.path.join(organization, repo)
 
         filename = request.args.get('filename')
-        headers = {'Content-Disposition': f'attachment; filename={filename}'} if filename else None
+        headers = {'Content-Disposition': f'attachment; filename="{filename}"'} if filename else None
 
         if self.storage.exists(path, oid):
             file = self.storage.get(path, oid)

--- a/giftless/transfer/basic_streaming.py
+++ b/giftless/transfer/basic_streaming.py
@@ -150,12 +150,13 @@ class BasicStreamingTransferAdapter(PreAuthorizingTransferAdapter, ViewProvider)
             download_url = ObjectsView.get_storage_url('get', organization, repo, oid)
             preauth_url = self._preauth_url(download_url, organization, repo, actions={'read'}, oid=oid)
 
-            params = {'filename': extra.get('filename') if extra else None}
-            preauth_url_with_params = add_query_params(preauth_url, params)
+            if extra and 'filename' in extra:
+                params = {'filename': extra['filename']}
+                preauth_url = add_query_params(preauth_url, params)
 
             response['actions'] = {
                 "download": {
-                    "href": preauth_url_with_params,
+                    "href": preauth_url,
                     "header": {},
                     "expires_in": self.action_lifetime
                 }

--- a/giftless/transfer/basic_streaming.py
+++ b/giftless/transfer/basic_streaming.py
@@ -18,7 +18,7 @@ from giftless.exc import InvalidPayload, NotFound
 from giftless.schema import ObjectSchema
 from giftless.storage import StreamingStorage, VerifiableStorage
 from giftless.transfer import PreAuthorizingTransferAdapter, ViewProvider
-from giftless.util import add_query_params, get_callable
+from giftless.util import add_query_params, get_callable, safe_filename
 from giftless.view import BaseView
 
 
@@ -82,6 +82,7 @@ class ObjectsView(BaseView):
         path = os.path.join(organization, repo)
 
         filename = request.args.get('filename')
+        filename = safe_filename(filename)
         headers = {'Content-Disposition': f'attachment; filename="{filename}"'} if filename else None
 
         if self.storage.exists(path, oid):

--- a/giftless/util.py
+++ b/giftless/util.py
@@ -55,7 +55,7 @@ def to_iterable(val: Any) -> Iterable:
     return (val,)
 
 
-def add_query_params(url: str, params: Dict) -> str:
+def add_query_params(url: str, params: Dict[str, Any]) -> str:
     """Safely add query params to a url that may or may not already contain
     query params.
 

--- a/giftless/util.py
+++ b/giftless/util.py
@@ -68,3 +68,17 @@ def add_query_params(url: str, params: Dict[str, Any]) -> str:
     urlencoded_params = urlencode(params)
     separator = '&' if '?' in url else '?'
     return f'{url}{separator}{urlencoded_params}'
+
+
+def safe_filename(original_filename: str) -> str:
+    """Returns a filename safe to use in HTTP headers, formed from the
+    given original filename.
+
+    >>> safe_filename("example(1).txt")
+    'example1.txt'
+
+    >>> safe_filename("_ex@mple 2%.old.xlsx")
+    '_exmple2.old.xlsx'
+    """
+    valid_chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.'
+    return ''.join(c for c in original_filename if c in valid_chars)

--- a/giftless/util.py
+++ b/giftless/util.py
@@ -1,7 +1,8 @@
 """Miscellanea
 """
 import importlib
-from typing import Any, Callable, Iterable, Optional
+from typing import Any, Callable, Dict, Iterable, Optional
+from urllib.parse import urlencode
 
 
 def get_callable(callable_str: str, base_package: Optional[str] = None) -> Callable:
@@ -52,3 +53,18 @@ def to_iterable(val: Any) -> Iterable:
     if isinstance(val, Iterable) and not isinstance(val, (str, bytes)):
         return val
     return (val,)
+
+
+def add_query_params(url: str, params: Dict):
+    """Safely add query params to a url that may or may not already contain
+    query params.
+
+    >>> add_query_params('https://example.org', {'param1': 'value1', 'param2': 'value2'})
+    'https://example.org?param1=value1&param2=value2'
+
+    >>> add_query_params('https://example.org?param1=value1', {'param2': 'value2'})
+    'https://example.org?param1=value1&param2=value2'
+    """
+    urlencoded_params = urlencode(params)
+    separator = '&' if '?' in url else '?'
+    return f'{url}{separator}{urlencoded_params}'

--- a/giftless/util.py
+++ b/giftless/util.py
@@ -55,7 +55,7 @@ def to_iterable(val: Any) -> Iterable:
     return (val,)
 
 
-def add_query_params(url: str, params: Dict):
+def add_query_params(url: str, params: Dict) -> str:
     """Safely add query params to a url that may or may not already contain
     query params.
 


### PR DESCRIPTION
This is a possible solution to issue #67. I have valued the opportunity to dig into giftless and understand how it works a bit.  I don't know if this PR is useful or not, but I'd find your review and otherwise proposed solution really interesting to understand. 

Some thoughts:

- I've used the GET args to wrap up the filename into the download url returned by batch. 
- From what I can see there are no tests for basic streaming transfer adapter to update?
- There is a small amount of reuse of code from [here](https://github.com/datopian/giftless/blob/59e6b0a5373558947382d69e891780f41dd88225/giftless/transfer/__init__.py#L58).  It's only a few lines, but could be refactored.  Just wasn't sure where would be best to put it?
- The `Content-Type` header is still not set.  I think this would probably require a PR to ckanext-blob-storage as well, so that the content type and filename are both passed through to the giftless batch request?  

