### PR TITLE
basic_streaming transfer adapter handling of 'filename' URL parameter

### DIFF
--- a/giftless/transfer/basic_streaming.py
+++ b/giftless/transfer/basic_streaming.py
@@ -82,7 +82,7 @@ class ObjectsView(BaseView):
         path = os.path.join(organization, repo)
 
         filename = request.args.get('filename')
-        filename = safe_filename(filename)
+        filename = safe_filename(filename) if filename else None
         disposition = request.args.get('disposition')
 
         headers = {}


### PR DESCRIPTION
'filter' the 'filename' URL parameter through 'safe_filename' IF it was actually sent with the request

It seems this URL parameter is not always passed by clients.
Out of my two setups, the windows based one does not, which led me to investigate.
    git version 2.31.1.windows.1 using ssh to clone a repository with lfs.url=http://...     - URL parameter not passed, hitting the failure mode mitigated by this PR
    git version 2.31.1 using a local file path to clone a repository with lfs.url=http://...   - Everything is fine
I have not investigated yet whether the URL parameter passing differences are by design or by accident, however it seems prudent for the transfer adapter to cleanly handle this case.