### PR TITLE
Replace use of os.path.join (which exhibits platform dependent behaviour) with posixpath.join where necessary

### DIFF
--- a/giftless/storage/amazon_s3.py
+++ b/giftless/storage/amazon_s3.py
@@ -1,4 +1,4 @@
-import os
+import posixpath
 from typing import Any, BinaryIO, Dict, Iterable, Optional
 
 import boto3  # type: ignore
@@ -112,7 +112,7 @@ class AmazonS3Storage(StreamingStorage, ExternalStorage):
             storage_prefix = self.path_prefix[1:]
         else:
             storage_prefix = self.path_prefix
-        return os.path.join(storage_prefix, prefix, oid)
+        return posixpath.join(storage_prefix, prefix, oid)
 
     def _s3_object(self, prefix, oid):
         return self.s3.Object(self.bucket_name, self._get_blob_path(prefix, oid))

--- a/giftless/storage/azure.py
+++ b/giftless/storage/azure.py
@@ -1,6 +1,6 @@
 import base64
 import logging
-import os
+import posixpath
 from collections import namedtuple
 from datetime import datetime, timedelta, timezone
 from typing import Any, BinaryIO, Dict, Iterable, List, Optional
@@ -163,7 +163,7 @@ class AzureBlobsStorage(StreamingStorage, ExternalStorage, MultipartStorage):
             storage_prefix = self.path_prefix[1:]
         else:
             storage_prefix = self.path_prefix
-        return os.path.join(storage_prefix, prefix, oid)
+        return posixpath.join(storage_prefix, prefix, oid)
 
     def _get_signed_url(self, prefix: str, oid: str, expires_in: int, filename: Optional[str] = None,
                         disposition: Optional[str] = None, **permissions: bool) -> str:

--- a/giftless/storage/google_cloud.py
+++ b/giftless/storage/google_cloud.py
@@ -1,7 +1,7 @@
 import base64
 import io
 import json
-import os
+import posixpath
 from datetime import timedelta
 from typing import Any, BinaryIO, Dict, Optional
 
@@ -90,7 +90,7 @@ class GoogleCloudStorage(StreamingStorage, ExternalStorage):
             storage_prefix = self.path_prefix[1:]
         else:
             storage_prefix = self.path_prefix
-        return os.path.join(storage_prefix, prefix, oid)
+        return posixpath.join(storage_prefix, prefix, oid)
 
     def _get_signed_url(self, prefix: str, oid: str, expires_in: int, http_method: str = 'GET',
                         filename: Optional[str] = None, disposition: Optional[str] = None) -> str:

--- a/giftless/transfer/basic_external.py
+++ b/giftless/transfer/basic_external.py
@@ -11,7 +11,7 @@ Different storage backends can be used with this adapter, as long as they
 implement the `ExternalStorage` interface defined here.
 """
 
-import os
+import posixpath
 from typing import Any, Dict, Optional
 
 from giftless.storage import ExternalStorage, exc
@@ -27,7 +27,7 @@ class BasicExternalBackendTransferAdapter(PreAuthorizingTransferAdapter, ViewPro
         self.action_lifetime = default_action_lifetime
 
     def upload(self, organization: str, repo: str, oid: str, size: int, extra: Optional[Dict[str, Any]] = None) -> Dict:
-        prefix = os.path.join(organization, repo)
+        prefix = posixpath.join(organization, repo)
         response = {"oid": oid,
                     "size": size}
 
@@ -50,7 +50,7 @@ class BasicExternalBackendTransferAdapter(PreAuthorizingTransferAdapter, ViewPro
 
     def download(self, organization: str, repo: str, oid: str, size: int,
                  extra: Optional[Dict[str, Any]] = None) -> Dict:
-        prefix = os.path.join(organization, repo)
+        prefix = posixpath.join(organization, repo)
         response = {"oid": oid,
                     "size": size}
 

--- a/giftless/transfer/basic_streaming.py
+++ b/giftless/transfer/basic_streaming.py
@@ -6,7 +6,7 @@ cloud, ...). This module defines an
 interface through which additional streaming backends can be implemented.
 """
 
-import os
+import posixpath
 from typing import Any, Dict, Optional
 
 from flask import Response, request, url_for
@@ -41,7 +41,7 @@ class VerifyView(BaseView):
 
         self._check_authorization(organization, repo, Permission.READ_META, oid=payload['oid'])
 
-        prefix = os.path.join(organization, repo)
+        prefix = posixpath.join(organization, repo)
         if not self.storage.verify_object(prefix, payload['oid'], payload['size']):
             raise InvalidPayload("Object does not exist or size does not match")
         return Response(status=200)
@@ -79,7 +79,7 @@ class ObjectsView(BaseView):
         """Get an file open file stream from local storage
         """
         self._check_authorization(organization, repo, Permission.READ, oid=oid)
-        path = os.path.join(organization, repo)
+        path = posixpath.join(organization, repo)
 
         filename = request.args.get('filename')
         filename = safe_filename(filename)
@@ -118,7 +118,7 @@ class BasicStreamingTransferAdapter(PreAuthorizingTransferAdapter, ViewProvider)
         response = {"oid": oid,
                     "size": size}
 
-        prefix = os.path.join(organization, repo)
+        prefix = posixpath.join(organization, repo)
         if not self.storage.exists(prefix, oid) or self.storage.get_size(prefix, oid) != size:
             response['actions'] = {
                 "upload": {
@@ -142,7 +142,7 @@ class BasicStreamingTransferAdapter(PreAuthorizingTransferAdapter, ViewProvider)
         response = {"oid": oid,
                     "size": size}
 
-        prefix = os.path.join(organization, repo)
+        prefix = posixpath.join(organization, repo)
         if not self.storage.exists(prefix, oid):
             response['error'] = {
                 "code": 404,

--- a/giftless/transfer/multipart.py
+++ b/giftless/transfer/multipart.py
@@ -1,7 +1,7 @@
 """Multipart Transfer Adapter
 """
 
-import os
+import posixpath
 from typing import Any, Dict, Optional
 
 from giftless.storage import MultipartStorage, exc
@@ -21,7 +21,7 @@ class MultipartTransferAdapter(PreAuthorizingTransferAdapter, ViewProvider):
         self.action_lifetime = default_action_lifetime
 
     def upload(self, organization: str, repo: str, oid: str, size: int, extra: Optional[Dict[str, Any]] = None) -> Dict:
-        prefix = os.path.join(organization, repo)
+        prefix = posixpath.join(organization, repo)
         response = {"oid": oid,
                     "size": size}
 
@@ -45,7 +45,7 @@ class MultipartTransferAdapter(PreAuthorizingTransferAdapter, ViewProvider):
 
     def download(self, organization: str, repo: str, oid: str, size: int,
                  extra: Optional[Dict[str, Any]] = None) -> Dict:
-        prefix = os.path.join(organization, repo)
+        prefix = posixpath.join(organization, repo)
         response = {"oid": oid,
                     "size": size}
 


### PR DESCRIPTION
os.path.join is used to form an url-like path (forward slash separators).
However, os.path.join separates by backslash on windows

Instead of using os.path (which the os module sets as 'import posixpath as path' or 'import ntpath as path', depending on platform), import posixpath directly and always get the correct behaviour (forward slash separators).

Below is an example of the current behaviour:
'upload' action request from test_basic_external_adapter.py::test_upload_action_new_file:

```
{'actions': {'upload': {'expires_in': 900,
                        'header': {'x-foo-bar': 'bazbaz'},
                        'href': 'https://cloudstorage.example.com/myorg\\myrepo/abcdef123456?expires_in=900'},
             'verify': {'expires_in': 43200,
                        'header': {},
                        'href': 'http://giftless.local/myorg/myrepo/objects/storage/verify'}},
```

On windows, the actions.upload.href field contains a backslash (myorg\\myrepo), as result of os.path.join use, and the test fails.

After this PR, forward slashes (myorg/myrepo) are generated.

Some call sites use os.path.join correctly (For instance, to form arguments to the open() function), and are not modified by the PR.
