### PR TITLE
ADX-997 [OAuth2] Authorization: Bearer token confuses giftless as to which token should be used

### DIFF
--- a/giftless/auth/jwt.py
+++ b/giftless/auth/jwt.py
@@ -192,9 +192,9 @@ class JWTAuthenticator(PreAuthorizedActionAuthenticator):
     def _authenticate(self, request: Request):
         """Authenticate a request
         """
-        token = self._get_token_from_headers(request)
+        token = self._get_token_from_qs(request)
         if token is None:
-            token = self._get_token_from_qs(request)
+            token = self._get_token_from_headers(request)
         if token is None:
             return None
 


### PR DESCRIPTION
Change order of token extraction, so it is sought first in URL string and later (if not found) in 'Authorization' header.