### PR TITLE
Fix pyjwt 2.x return type issue and make typing happy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /.coverage
 /.make-cache
 /.tox
+/.DS_Store

--- a/giftless/auth/__init__.py
+++ b/giftless/auth/__init__.py
@@ -51,7 +51,8 @@ class PreAuthorizedActionAuthenticator(abc.ABC):
 
 class Authentication:
 
-    def __init__(self, app=None, default_identity: Identity = None):
+    def __init__(self, app=None,
+                 default_identity: Optional[Identity] = None) -> None:
         self._default_identity = default_identity
         self._authenticators: List[Authenticator] = []
         self._unauthorized_handler: Optional[Callable] = None

--- a/giftless/auth/identity.py
+++ b/giftless/auth/identity.py
@@ -1,4 +1,4 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 from collections import defaultdict
 from enum import Enum
 from typing import Dict, Optional, Set
@@ -29,6 +29,7 @@ class Identity(ABC):
     id: Optional[str] = None
     email: Optional[str] = None
 
+    @abstractmethod
     def is_authorized(self, organization: str, repo: str, permission: Permission, oid: Optional[str] = None) -> bool:
         """Tell if user is authorized to perform an operation on an object / repo
         """

--- a/giftless/auth/jwt.py
+++ b/giftless/auth/jwt.py
@@ -151,7 +151,7 @@ class JWTAuthenticator(PreAuthorizedActionAuthenticator):
         if lifetime:
             token_payload['exp'] = datetime.now(tz=UTC) + timedelta(seconds=lifetime)
 
-        return self._generate_token(**token_payload).decode('ascii')
+        return self._generate_token(**token_payload)
 
     @staticmethod
     def _generate_action_scopes(org: str, repo: str, actions: Optional[Set[str]] = None, oid: Optional[str] = None) \
@@ -163,7 +163,7 @@ class JWTAuthenticator(PreAuthorizedActionAuthenticator):
         obj_id = f'{org}/{repo}/{oid}'
         return str(Scope('obj', obj_id, actions))
 
-    def _generate_token(self, **kwargs) -> bytes:
+    def _generate_token(self, **kwargs) -> str:
         """Generate a JWT token that can be used later to authenticate a request
         """
         if not self.private_key:
@@ -187,9 +187,9 @@ class JWTAuthenticator(PreAuthorizedActionAuthenticator):
         if self.key_id:
             headers['kid'] = self.key_id
 
-        return jwt.encode(payload, self.private_key, algorithm=self.algorithm, headers=headers)  # type: ignore
+        return jwt.encode(payload, self.private_key, algorithm=self.algorithm, headers=headers)
 
-    def _authenticate(self, request: Request):
+    def _authenticate(self, request: Request) -> Any:
         """Authenticate a request
         """
         token = self._get_token_from_headers(request)

--- a/giftless/storage/__init__.py
+++ b/giftless/storage/__init__.py
@@ -1,5 +1,5 @@
 import mimetypes
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import Any, BinaryIO, Dict, Iterable, Optional
 
 from . import exc
@@ -10,6 +10,7 @@ class VerifiableStorage(ABC):
 
     All streaming backends should be 'verifiable'.
     """
+    @abstractmethod
     def verify_object(self, prefix: str, oid: str, size: int) -> bool:
         """Check that object exists and has the right size
 
@@ -21,21 +22,27 @@ class VerifiableStorage(ABC):
 class StreamingStorage(VerifiableStorage, ABC):
     """Interface for streaming storage adapters
     """
+    @abstractmethod
     def get(self, prefix: str, oid: str) -> Iterable[bytes]:
         pass
 
+    @abstractmethod
     def put(self, prefix: str, oid: str, data_stream: BinaryIO) -> int:
         pass
 
+    @abstractmethod
     def exists(self, prefix: str, oid: str) -> bool:
         pass
 
+    @abstractmethod
     def get_size(self, prefix: str, oid: str) -> int:
         pass
 
+    @abstractmethod
     def get_mime_type(self, prefix: str, oid: str) -> Optional[str]:
         return "application/octet-stream"
 
+    @abstractmethod
     def verify_object(self, prefix: str, oid: str, size: int):
         """Verify that an object exists
         """
@@ -48,17 +55,21 @@ class StreamingStorage(VerifiableStorage, ABC):
 class ExternalStorage(VerifiableStorage, ABC):
     """Interface for streaming storage adapters
     """
+    @abstractmethod
     def get_upload_action(self, prefix: str, oid: str, size: int, expires_in: int,
                           extra: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         pass
 
+    @abstractmethod
     def get_download_action(self, prefix: str, oid: str, size: int, expires_in: int,
                             extra: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         pass
 
+    @abstractmethod
     def exists(self, prefix: str, oid: str) -> bool:
         pass
 
+    @abstractmethod
     def get_size(self, prefix: str, oid: str) -> int:
         pass
 
@@ -70,17 +81,21 @@ class ExternalStorage(VerifiableStorage, ABC):
 
 
 class MultipartStorage(VerifiableStorage, ABC):
+    @abstractmethod
     def get_multipart_actions(self, prefix: str, oid: str, size: int, part_size: int, expires_in: int,
                               extra: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         pass
 
+    @abstractmethod
     def get_download_action(self, prefix: str, oid: str, size: int, expires_in: int,
                             extra: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         pass
 
+    @abstractmethod
     def exists(self, prefix: str, oid: str) -> bool:
         pass
 
+    @abstractmethod
     def get_size(self, prefix: str, oid: str) -> int:
         pass
 

--- a/giftless/storage/google_cloud.py
+++ b/giftless/storage/google_cloud.py
@@ -3,9 +3,9 @@ import io
 import json
 import posixpath
 from datetime import timedelta
-from typing import Any, BinaryIO, Dict, Optional
+from typing import Any, BinaryIO, Dict, Optional, Union
 
-import google.auth
+import google.auth  # type: ignore
 from google.auth import impersonated_credentials
 from google.cloud import storage  # type: ignore
 from google.oauth2 import service_account  # type: ignore
@@ -109,8 +109,9 @@ class GoogleCloudStorage(StreamingStorage, ExternalStorage):
 
     def _get_signed_url(self, prefix: str, oid: str, expires_in: int, http_method: str = 'GET',
                         filename: Optional[str] = None, disposition: Optional[str] = None) -> str:
-        creds = self.credentials
+        creds: Optional[Union[service_account.Credentials, impersonated_credentials.Credentials]] = self.credentials
         if creds is None:
+            # Try Workload Identity
             creds = self._get_workload_identity_credentials(expires_in)
         bucket = self.storage_client.bucket(self.bucket_name)
         blob = bucket.blob(self._get_blob_path(prefix, oid))
@@ -137,7 +138,7 @@ class GoogleCloudStorage(StreamingStorage, ExternalStorage):
         else:
             return None  # Will use Workload Identity if available
 
-    def _get_workload_identity_credentials(self, expires_in: int) -> None:
+    def _get_workload_identity_credentials(self, expires_in: int) -> impersonated_credentials.Credentials:
         lifetime = expires_in
         if lifetime > 3600:
             lifetime = 3600  # Signing credentials are good for one hour max

--- a/giftless/storage/local_storage.py
+++ b/giftless/storage/local_storage.py
@@ -13,7 +13,7 @@ class LocalStorage(StreamingStorage, MultipartStorage, ViewProvider):
     While it can be used in production, large scale deployment will most likely
     want to use a more scalable solution such as one of the cloud storage backends.
     """
-    def __init__(self, path: str = None, **_):
+    def __init__(self, path: Optional[str] = None, **_) -> None:
         if path is None:
             path = 'lfs-storage'
         self.path = path
@@ -49,11 +49,11 @@ class LocalStorage(StreamingStorage, MultipartStorage, ViewProvider):
 
     def get_multipart_actions(self, prefix: str, oid: str, size: int, part_size: int, expires_in: int,
                               extra: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-        return super().get_multipart_actions(prefix, oid, size, part_size, expires_in, extra)
+        return {}
 
     def get_download_action(self, prefix: str, oid: str, size: int, expires_in: int,
                             extra: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-        return super().get_download_action(prefix, oid, size, expires_in, extra)
+        return {}
 
     def register_views(self, app):
         super().register_views(app)


### PR DESCRIPTION
The functional change here is not to call decode() when what we get back from jwt.encode() is already a string rather than a bytes object.

We also update to the released flask-classful 0.16, which will unjam modernization of the rest of the codebase, which requires rewriting a bit of the authorization handling because parse_authorization_headers() will no longer be part of werkzeug (it's a from_header classmethod in werkzeug.Authorization).

I got sick of .DS_Store on my Mac making the repository dirty, so I added it to .gitignore.

Everything else is to get mypy happy with the current codebase--mostly marking all the things that were Optional and defaulted to None as such, marking abstract methods as such, and not then calling those abstract methods.  That's going to make modernizing the codebase easier too.