### PR TITLE
fix(Dockerfile): Graceful shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ ARG PORT=5000
 EXPOSE $PORT
 
 ENTRYPOINT ["tini", "uwsgi", "--"]
+# TODO remove this STOPSIGNAL override after uwsgi>=2.1
 STOPSIGNAL SIGQUIT
 
 CMD ["-s", "127.0.0.1:${PORT}", "-M", "-T", "--threads", "2", "-p", "2", \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ ARG PORT=5000
 EXPOSE $PORT
 
 ENTRYPOINT ["tini", "uwsgi", "--"]
+STOPSIGNAL SIGQUIT
 
 CMD ["-s", "127.0.0.1:${PORT}", "-M", "-T", "--threads", "2", "-p", "2", \
      "--manage-script-name", "--callable", "app"]


### PR DESCRIPTION
`uwsgi` needs SIGINT/SIGQUIT to shutdown gracefullly. The otherwise default SIGTERM is used to “brutally reload the stack”.

Closes: https://github.com/datopian/giftless/issues/131