### PR TITLE
Add unit tests for github auth provider

### DIFF
--- a/giftless/auth/github.py
+++ b/giftless/auth/github.py
@@ -217,8 +217,9 @@ class Config:
 
         @ma.post_load
         def make_object(
-            self, data: Mapping[str, Any], **_kwargs: Mapping
+            self, data: MutableMapping[str, Any], **_kwargs: Mapping
         ) -> "Config":
+            data["api_url"] = data["api_url"].rstrip("/")
             return Config(**data)
 
     @classmethod
@@ -363,7 +364,7 @@ class GithubAuthenticator:
             self.token = self._extract_token(request)
 
     def __init__(self, cfg: Config) -> None:
-        self._api_url = cfg.api_url.rstrip("/")
+        self._api_url = cfg.api_url
         self._api_headers = {"Accept": "application/vnd.github+json"}
         if cfg.api_version:
             self._api_headers["X-GitHub-Api-Version"] = cfg.api_version
@@ -479,8 +480,12 @@ class GithubAuthenticator:
             self._authorize(ctx, user)
             return user
 
+    @property
+    def api_url(self) -> str:
+        return self._api_url
 
-def factory(**options: Mapping[str, Any]) -> GithubAuthenticator:
+
+def factory(**options: Any) -> GithubAuthenticator:
     """Build GitHub Authenticator from supplied options."""
     config = Config.from_dict(options)
     return GithubAuthenticator(config)

--- a/giftless/auth/github.py
+++ b/giftless/auth/github.py
@@ -369,7 +369,8 @@ class GithubAuthenticator:
             return token
 
         def __post_init__(self, request: flask.Request) -> None:
-            self.org, self.repo = request.path.split("/", maxsplit=3)[1:3]
+            org_repo_getter = itemgetter("organization", "repo")
+            self.org, self.repo = org_repo_getter(request.view_args or {})
             self.token = self._extract_token(request)
 
     def __init__(self, cfg: Config) -> None:

--- a/giftless/auth/github.py
+++ b/giftless/auth/github.py
@@ -29,7 +29,7 @@ _LockType: TypeAlias = Union["Lock", "_RLock"]
 class SingleCallContext:
     """Thread-safety context for the single_call_method decorator."""
 
-    # condition variable blocking a call with particular arguments
+    # reentrant lock guarding a call with particular arguments
     rlock: _RLock = dataclasses.field(default_factory=RLock)
     start_call: bool = True
     result: Any = None

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -9,6 +9,7 @@ pytest-mypy
 pytest-env
 pytest-cov
 pytest-vcr
+responses
 
 pytz
 types-pytz

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -163,13 +163,17 @@ pytz==2023.3.post1
 pyyaml==6.0.1
     # via
     #   -c requirements/main.txt
+    #   responses
     #   vcrpy
 recommonmark==0.7.1
     # via -r requirements/dev.in
 requests==2.31.0
     # via
     #   -c requirements/main.txt
+    #   responses
     #   sphinx
+responses==0.25.0
+    # via -r requirements/dev.in
 rsa==4.9
     # via
     #   -c requirements/main.txt
@@ -241,6 +245,7 @@ urllib3==2.0.7
     # via
     #   -c requirements/main.txt
     #   requests
+    #   responses
     #   types-requests
 vcrpy==5.1.0
     # via pytest-vcr

--- a/tests/auth/test_github.py
+++ b/tests/auth/test_github.py
@@ -18,12 +18,16 @@ def test_ensure_default_lock() -> None:
 
 
 def _concurrent_side_effects(
-    decorator: Callable[[Callable[..., Any]], Any], thread_cnt: int = 4
+    decorator: Callable[[Callable[..., Any]], Any],
+    thread_cnt: int = 4,
+    exception: type[Exception] | None = None,
 ) -> tuple[list, list, list]:
     @decorator
     def decorated_method(_ignored_self: Any, index: int) -> int:
         sleep(0.1)
         side_effects[index] = index
+        if exception is not None:
+            raise exception(index)
         return index
 
     results: list[int | None] = [None] * thread_cnt
@@ -66,7 +70,19 @@ def test_single_call_method_decorator_default_args() -> None:
     assert results == side_effects
 
 
-def test_single_call_method_decorator_call_first() -> None:
+def test_single_call_method_decorator_default_exception() -> None:
+    decorator = gh.single_call_method()
+    results, side_effects, exceptions = _concurrent_side_effects(
+        decorator, exception=Exception
+    )
+    # same as test_single_call_method_decorator_default_no_args, but checking
+    # if the decorator factory works properly with no explicit args
+    assert all(r is None for r in results)
+    assert all(se is not None for se in side_effects)
+    assert all(e is not None for e in exceptions)
+
+
+def test_single_call_method_decorator_call_once() -> None:
     # using a constant hash key to put all threads in the same bucket
     decorator = gh.single_call_method(key=lambda *args: 0)
     threads = 4
@@ -81,3 +97,48 @@ def test_single_call_method_decorator_call_first() -> None:
     # at least one thread got stuck
     assert len(chosen_ones) < threads
     assert all(r in chosen_ones for r in results)
+
+
+def test_single_call_method_decorator_call_once_exception() -> None:
+    # using a constant hash key to put all threads in the same bucket
+    decorator = gh.single_call_method(key=lambda *args: 0)
+    threads = 4
+    results, side_effects, exceptions = _concurrent_side_effects(
+        decorator, threads, Exception
+    )
+    assert all(r is None for r in results)
+    assert all(e is not None for e in exceptions)
+    chosen_ones = [se for se in side_effects if se is not None]
+    # at least one thread got stuck
+    assert len(chosen_ones) < threads
+    # make sure the exceptions come from the calling thread
+    assert all(e.args[0] in chosen_ones for e in exceptions)
+
+
+def test_cachedmethod_threadsafe_default_key() -> None:
+    # cache all the uncoupled calls
+    cache: dict[Any, Any] = {}
+    threads = 4
+    decorator = gh.cachedmethod_threadsafe(lambda _self: cache)
+    results, side_effects, exceptions = _concurrent_side_effects(
+        decorator, threads
+    )
+    assert all(e is None for e in exceptions)
+    assert results == side_effects
+    assert len(cache) == threads
+
+
+def test_cachedmethod_threadsafe_call_once() -> None:
+    # one result ends up cached, even if call produces different results
+    # (this is supposed to be used for idempotent methods, so multiple calls
+    # are supposed to produce identical results)
+    cache: dict[Any, Any] = {}
+    decorator = gh.cachedmethod_threadsafe(
+        lambda _self: cache, key=lambda *args: 0
+    )
+    results, side_effects, exceptions = _concurrent_side_effects(decorator)
+    assert all(e is None for e in exceptions)
+    chosen_ones = [se for se in side_effects if se is not None]
+    assert len(cache) == 1
+    cached_result = next(iter(cache.values()))
+    assert cached_result in chosen_ones

--- a/tests/auth/test_github.py
+++ b/tests/auth/test_github.py
@@ -1,0 +1,83 @@
+"""Unit tests for auth.github module."""
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from random import shuffle
+from time import sleep
+from typing import Any
+
+import giftless.auth.github as gh
+
+
+def test_ensure_default_lock() -> None:
+    lock_getter = gh._ensure_lock()
+    lock = lock_getter(None)
+    with lock:
+        # Is it a RLock or just Lock?
+        if lock.acquire(blocking=False):
+            lock.release()
+
+
+def _concurrent_side_effects(
+    decorator: Callable[[Callable[..., Any]], Any], thread_cnt: int = 4
+) -> tuple[list, list, list]:
+    @decorator
+    def decorated_method(_ignored_self: Any, index: int) -> int:
+        sleep(0.1)
+        side_effects[index] = index
+        return index
+
+    results: list[int | None] = [None] * thread_cnt
+    side_effects: list[int | None] = [None] * thread_cnt
+    exceptions: list[Exception | None] = [None] * thread_cnt
+
+    with ThreadPoolExecutor(
+        max_workers=thread_cnt, thread_name_prefix="scm-"
+    ) as executor:
+        thread_indices = list(range(thread_cnt))
+        shuffle(thread_indices)
+        futures = {
+            executor.submit(decorated_method, i, i): i for i in thread_indices
+        }
+        for future in as_completed(futures):
+            i = futures[future]
+            try:
+                result = future.result()
+            except Exception as exc:
+                exceptions[i] = exc
+            else:
+                results[i] = result
+
+    return results, side_effects, exceptions
+
+
+def test_single_call_method_decorator_default_no_args() -> None:
+    decorator = gh.single_call_method
+    results, side_effects, exceptions = _concurrent_side_effects(decorator)
+    # the differing index (taken into account by default) breaks call coupling,
+    # so this decoration has no effect and all calls get through
+    assert results == side_effects
+
+
+def test_single_call_method_decorator_default_args() -> None:
+    decorator = gh.single_call_method()
+    results, side_effects, exceptions = _concurrent_side_effects(decorator)
+    # same as test_single_call_method_decorator_default_no_args, but checking
+    # if the decorator factory works properly with no explicit args
+    assert results == side_effects
+
+
+def test_single_call_method_decorator_call_first() -> None:
+    # using a constant hash key to put all threads in the same bucket
+    decorator = gh.single_call_method(key=lambda *args: 0)
+    threads = 4
+    results, side_effects, exceptions = _concurrent_side_effects(
+        decorator, threads
+    )
+    assert all(e is None for e in exceptions)
+    # as there's just a sleep in the decorated_method, technically multiple
+    # threads could enter the method call (and thus produce side_effects),
+    # but the expectation is the sleep is long enough for all to get stuck
+    chosen_ones = [se for se in side_effects if se is not None]
+    # at least one thread got stuck
+    assert len(chosen_ones) < threads
+    assert all(r in chosen_ones for r in results)


### PR DESCRIPTION
This PR add 100% (well 99% due to typing clutter) coverage unit tests for the github auth provider.

It fixes a handful of mostly cosmetic things in the original code, that popped up during the work.

One considerably more significant change is the introduction of the authorization "proxy" cache, which ensures that the core giftless code will always get a valid `is_authorized()` response for the user calling giftless, even if the usual auth proxy is configured too low to withstand some harsh hammering conditions.

Closes: https://github.com/datopian/giftless/issues/148