### PR TITLE
fix(docker): remove ARG PORT

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,5 @@
 .pytest_cache
 .mypy_cache
 /.idea
+.tox
+.make-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,21 +49,15 @@ RUN chown $USER_NAME $STORAGE_DIR
 ARG EXTRA_PACKAGES="wsgi_cors_middleware"
 RUN pip install ${EXTRA_PACKAGES}
 
+USER $USER_NAME
+
 WORKDIR /app
 
 ENV UWSGI_MODULE "giftless.wsgi_entrypoint"
 
-ARG PORT=5000
-EXPOSE $PORT
-# embed the default port into docker-entrypoint.sh, and make it executable
-RUN set -eu ;\
-    de=scripts/docker-entrypoint.sh ;\
-    sed -i "/^default_port=/s/5000/$PORT/" "$de" ;\
-    chmod +x "$de"
-
-USER $USER_NAME
-
-ENTRYPOINT ["tini", "--", "scripts/docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "uwsgi", "--"]
+CMD ["-s", "127.0.0.1:5000", "-M", "-T", "--threads", "2", "-p", "2", \
+     "--manage-script-name", "--callable", "app"]
 
 # TODO remove this STOPSIGNAL override after uwsgi>=2.1
 STOPSIGNAL SIGQUIT

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-default_port=5000
-if [ $# -eq 0 ]; then
-  # listen on localhost:PORT by default
-  exec uwsgi -s "127.0.0.1:$default_port" -M -T --threads 2 -p 2 --manage-script-name --callable app
-else
-  # use custom arguments
-  exec uwsgi "$@"
-fi

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+default_port=5000
+if [ $# -eq 0 ]; then
+  # listen on localhost:PORT by default
+  exec uwsgi -s "127.0.0.1:$default_port" -M -T --threads 2 -p 2 --manage-script-name --callable app
+else
+  # use custom arguments
+  exec uwsgi "$@"
+fi


### PR DESCRIPTION
**EDIT: This OP no longer holds true, things got rather simplified instead. Follow the discussion below.**

Yet another gratuitous fix nobody asked for :)

Shell parameter expansion doesn't happen inside the CMD array, so literal `${PORT}` gets passed to `uwsgi`, which it happily accepts, but, well, doesn't work as expected.

One either needs to set an `ENV` var and use it in an entrypoint shell script or, if one doesn't want to pollute the container's env space, modify the argument (with sed) within the entrypoint itself. That's what I did.

Also this change ignores a couple fat development directories that complicate local `make docker` runs.

PS: I'm not a fan of docker entrypoints, but this couldn't be solved better, unless using custom variable expansion like this in the `ENTRYPOINT`:
```bash
r=(); for arg; do eval $'r+=("$(cat <<EoF\n'$arg$'\nEoF\n)")'; shift; done; exec uwsgi "${r[@]}"
```
which, although surely very beautiful, is also pretty obscure, rather unsafe and adds one more (unwanted) level of variable expansion to the arguments passed as the `CMD`.