### PR TITLE
Fix authenticated flag in a transfer adapter response

### DIFF
--- a/giftless/auth/__init__.py
+++ b/giftless/auth/__init__.py
@@ -53,7 +53,7 @@ class PreAuthorizedActionAuthenticator(abc.ABC):
         oid: str | None = None,
         lifetime: int | None = None,
     ) -> dict[str, str]:
-        """Authorize an action by adding credientaisl to the query string."""
+        """Authorize an action by adding credentials to the query string."""
 
     @abc.abstractmethod
     def get_authz_header(

--- a/giftless/transfer/basic_external.py
+++ b/giftless/transfer/basic_external.py
@@ -60,7 +60,7 @@ class BasicExternalBackendTransferAdapter(
             )
         )
         if response.get("actions", {}).get("upload"):  # type:ignore[attr-defined]
-            response["authenticated"] = True
+            response["authenticated"] = self._provides_preauth
             headers = self._preauth_headers(
                 organization,
                 repo,
@@ -98,7 +98,7 @@ class BasicExternalBackendTransferAdapter(
             response["error"] = e.as_dict()
 
         if response.get("actions", {}).get("download"):  # type:ignore[attr-defined]
-            response["authenticated"] = True
+            response["authenticated"] = self._provides_preauth
 
         return response
 

--- a/giftless/transfer/basic_streaming.py
+++ b/giftless/transfer/basic_streaming.py
@@ -204,7 +204,7 @@ class BasicStreamingTransferAdapter(
                     "expires_in": self.VERIFY_LIFETIME,
                 },
             }
-            response["authenticated"] = True
+            response["authenticated"] = self._provides_preauth
 
         return response
 
@@ -250,7 +250,7 @@ class BasicStreamingTransferAdapter(
                     "expires_in": self.action_lifetime,
                 }
             }
-            response["authenticated"] = True
+            response["authenticated"] = self._provides_preauth
 
         return response
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ build-backend = "setuptools.build_meta"
 # Use single-quoted strings so TOML treats the string like a Python r-string
 # Multi-line strings are implicitly treated by black as regular expressions
 
+[tool.setuptools.packages.find]
+include = ["giftless"]
+
 [tool.coverage.run]
 parallel = true
 branch = true

--- a/tests/auth/test_github.py
+++ b/tests/auth/test_github.py
@@ -197,9 +197,9 @@ def test_github_identity_core() -> None:
     user_dict = DEFAULT_USER_DICT | {"other_field": "other_value"}
     cache_cfg = DEFAULT_CONFIG.cache
     user = gh.GithubIdentity.from_dict(user_dict, cc=cache_cfg)
-    assert (user.login, user.id, user.name, user.email) == DEFAULT_USER_ARGS
+    assert (user.id, user.github_id, user.name, user.email) == DEFAULT_USER_ARGS
     assert all(arg in repr(user) for arg in DEFAULT_USER_ARGS[:3])
-    assert hash(user) == hash((user.login, user.id))
+    assert hash(user) == hash((user.id, user.github_id))
 
     args2 = (*DEFAULT_USER_ARGS[:2], "spammer", "spam@camelot.gov.uk")
     user2 = gh.GithubIdentity(*args2, cc=cache_cfg)


### PR DESCRIPTION
The `authenticated` flag in the [`/batch` endpoint response](https://github.com/git-lfs/git-lfs/blob/main/docs/api/batch.md#successful-responses) is always `true`, which surely is not the case when the `PRE_AUTHORIZED_ACTION_PROVIDER` is `null` in the startup configuration.

This prevented me from using the github auth provider, because with `authenticated: true` the git client doesn't try the stored credentials previously used to authenticate against the `batch` endpoint.

There's couple loosely related tweaks included, see the details in the particular commits.