### PR TITLE
feat(github): simplify identity caching

### DIFF
--- a/giftless/auth/identity.py
+++ b/giftless/auth/identity.py
@@ -29,9 +29,15 @@ class Identity(ABC):
     perform some actions.
     """
 
-    name: str | None = None
-    id: str | None = None
-    email: str | None = None
+    def __init__(
+        self,
+        name: str | None = None,
+        id: str | None = None,
+        email: str | None = None,
+    ) -> None:
+        self.name = name
+        self.id = id
+        self.email = email
 
     @abstractmethod
     def is_authorized(
@@ -58,9 +64,7 @@ class DefaultIdentity(Identity):
         id: str | None = None,
         email: str | None = None,
     ) -> None:
-        self.name = name
-        self.id = id
-        self.email = email
+        super().__init__(name, id, email)
         self._allowed: PermissionTree = defaultdict(
             lambda: defaultdict(lambda: defaultdict(set))
         )

--- a/tests/auth/test_github.py
+++ b/tests/auth/test_github.py
@@ -196,8 +196,8 @@ def test_github_identity_core() -> None:
     # use some value to get filtered out
     token_dict = DEFAULT_TOKEN_DICT | {"other_field": "other_value"}
     cache_cfg = DEFAULT_CONFIG.cache
-    raw_identity = gh._RawGithubIdentity.from_token(token_dict)
-    user = gh.GithubIdentity(raw_identity, cache_cfg)
+    core_identity = gh._CoreGithubIdentity.from_token(token_dict)
+    user = gh.GithubIdentity(core_identity, token_dict, cache_cfg)
     assert (user.id, user.github_id, user.name, user.email) == tuple(
         DEFAULT_TOKEN_DICT.values()
     )
@@ -210,8 +210,10 @@ def test_github_identity_core() -> None:
 
 
 def test_github_identity_authorization_cache() -> None:
-    raw_identity = gh._RawGithubIdentity.from_token(DEFAULT_TOKEN_DICT)
-    user = gh.GithubIdentity(raw_identity, DEFAULT_CONFIG.cache)
+    core_identity = gh._CoreGithubIdentity.from_token(DEFAULT_TOKEN_DICT)
+    user = gh.GithubIdentity(
+        core_identity, DEFAULT_TOKEN_DICT, DEFAULT_CONFIG.cache
+    )
     assert not user.is_authorized(ORG, REPO, Permission.READ_META)
     user.authorize(ORG, REPO, {Permission.READ_META, Permission.READ})
     assert user.permissions(ORG, REPO) == {
@@ -224,8 +226,10 @@ def test_github_identity_authorization_cache() -> None:
 
 
 def test_github_identity_authorization_proxy_cache_only() -> None:
-    raw_identity = gh._RawGithubIdentity.from_token(DEFAULT_TOKEN_DICT)
-    user = gh.GithubIdentity(raw_identity, ZERO_CACHE_CONFIG)
+    core_identity = gh._CoreGithubIdentity.from_token(DEFAULT_TOKEN_DICT)
+    user = gh.GithubIdentity(
+        core_identity, DEFAULT_TOKEN_DICT, ZERO_CACHE_CONFIG
+    )
     org, repo, repo2 = ORG, REPO, "repo2"
     user.authorize(org, repo, Permission.all())
     user.authorize(org, repo2, Permission.all())


### PR DESCRIPTION
This is an update on github auth plugin caching, which I eventually found problematic (then I made it ugly, sorted my thoughts, and finally made it better than it was). I'd squash it, but then you'd lose the commit genesis, which might be interesting, so I'll keep it for the PR (which I'd still rather recommend squash-merging :smile:)

The change is mostly simplifying it from the user perspective. I also learned a new thing -  the `weakref` library that allows one to do stuff when an object's refcount goes to 0. I used that to manage a dictionary of unique users I need to keep around to track one user's multiple tokens. Because `cachetools` caches don't have any native mechanism to notify anyone that an entry got evicted, I originally had size-capped caches for both the tokens and users, but that created a kind of a split-brain problem, where the user referenced from both caches could get evicted independently, and that was bad.

Now I'm keeping track of the users in a size-unlimited cache which - thanks to weak references - can clean itself up after all its references in the primary cache get evicted. This keeps the user cache fresh and not growing forever, which would otherwise likely require some periodic cleanup.