### PR TITLE
feat(github): Allow to configure which orgs/repos the github auth applies to

### DIFF
--- a/docs/source/auth-providers.md
+++ b/docs/source/auth-providers.md
@@ -233,7 +233,7 @@ This token represents a special identity of an "application installation", actin
 * `api_url` (`str` = `"https://api.github.com"`): Base URL for the GitHub API (enterprise servers have API at `"https://<custom-hostname>/api/v3/"`).
 * `api_timeout` (`float | tuple[float, float]` = `(10.0, 20.0)`): Timeout for the GitHub API calls ([details](https://requests.readthedocs.io/en/stable/user/advanced/#timeouts)).
 * `api_version` (`str | None` = `"2022-11-28"`): Target GitHub API version; set to `None` to use GitHub's latest (rather experimental).
-* `restrict_to` (`dict[str, list[str] | None] | None` = `None`): Optional (but very recommended) dictionary of GitHub organizations/users the authentication is restricted to. Each key (organization name) in the dictionary can contain a list of further restricted repository names. When the list is empty (or null), only the organizations are considered.
+* `restrict_to` (`dict[str, list[str] | None] | None` = `None`): Optional (but highly recommended) dictionary of GitHub organizations/users the authentication is restricted to. Each key (organization name) in the dictionary can contain a list of further restricted repository names. When the list is empty (or null), only the organizations are considered.
 * `cache` (`dict`): Cache configuration section
   * `token_max_size` (`int` = `32`): Max number of entries in the token -> user LRU cache. This cache holds the authentication data for a token. Evicted tokens will need to be re-authenticated.
   * `auth_max_size` (`int` = `32`): Max number of [un]authorized org/repos TTL(LRU) for each user. Evicted repos will need to get re-authorized.

--- a/docs/source/auth-providers.md
+++ b/docs/source/auth-providers.md
@@ -233,6 +233,7 @@ This token represents a special identity of an "application installation", actin
 * `api_url` (`str` = `"https://api.github.com"`): Base URL for the GitHub API (enterprise servers have API at `"https://<custom-hostname>/api/v3/"`).
 * `api_timeout` (`float | tuple[float, float]` = `(10.0, 20.0)`): Timeout for the GitHub API calls ([details](https://requests.readthedocs.io/en/stable/user/advanced/#timeouts)).
 * `api_version` (`str | None` = `"2022-11-28"`): Target GitHub API version; set to `None` to use GitHub's latest (rather experimental).
+* `restrict_to` (`dict[str, list[str] | None] | None` = `None`): Optional (but very recommended) dictionary of GitHub organizations/users the authentication is restricted to. Each key (organization name) in the dictionary can contain a list of further restricted repository names. When the list is empty (or null), only the organizations are considered.
 * `cache` (`dict`): Cache configuration section
   * `token_max_size` (`int` = `32`): Max number of entries in the token -> user LRU cache. This cache holds the authentication data for a token. Evicted tokens will need to be re-authenticated.
   * `auth_max_size` (`int` = `32`): Max number of [un]authorized org/repos TTL(LRU) for each user. Evicted repos will need to get re-authorized.

--- a/giftless/auth/github.py
+++ b/giftless/auth/github.py
@@ -265,9 +265,7 @@ class Config:
         api_timeout = RequestsTimeout(load_default=(5.0, 10.0))
         restrict_to = ma.fields.Dict(
             keys=ma.fields.String(),
-            values=ma.fields.List(
-                ma.fields.String(allow_none=True), allow_none=True
-            ),
+            values=ma.fields.List(ma.fields.String(), allow_none=True),
             load_default=None,
             allow_none=True,
         )
@@ -342,7 +340,7 @@ class CallContext:
                 ) from None
             if rest_repos and self.repo not in rest_repos:
                 raise Unauthorized(
-                    f"Unauthorized GitHub repository '{self.repo}'"
+                    f"Unauthorized GitHub repository '{self.org}/{self.repo}'"
                 )
 
     def __enter__(self) -> "CallContext":

--- a/tests/auth/test_github.py
+++ b/tests/auth/test_github.py
@@ -410,6 +410,26 @@ def mock_installation_repos(
     return cast(responses.BaseResponse, ret)
 
 
+def test_call_context_restrict_to_org_only(app: flask.Flask) -> None:
+    cfg = gh.Config.from_dict({"restrict_to": {ORG: None}})
+    with auth_request_context(app):
+        ctx = gh.CallContext(cfg, flask.request)
+        assert ctx is not None
+    with auth_request_context(app, org="bogus"):
+        with pytest.raises(Unauthorized):
+            gh.CallContext(cfg, flask.request)
+
+
+def test_call_context_restrict_to_org_and_repo(app: flask.Flask) -> None:
+    cfg = gh.Config.from_dict({"restrict_to": {ORG: [REPO]}})
+    with auth_request_context(app):
+        ctx = gh.CallContext(cfg, flask.request)
+        assert ctx is not None
+    with auth_request_context(app, repo="bogus"):
+        with pytest.raises(Unauthorized):
+            gh.CallContext(cfg, flask.request)
+
+
 def test_call_context_api_get_no_session(app: flask.Flask) -> None:
     with auth_request_context(app):
         ctx = gh.CallContext(DEFAULT_CONFIG, flask.request)


### PR DESCRIPTION
This is done via a configuration item `restrict_to`, which is a dict of Github orgs, potentially containing a list of repos.

```yaml
restrict_to:
  org1:
  - repo1  # accept org1/repo1
  - repo2  # accept org1/repo2
  org2: []  # accept all repos of that org
```

Closes: https://github.com/datopian/giftless/issues/166